### PR TITLE
Improve CLI behavior in non-TTY environments

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -303,7 +303,7 @@ async function main() {
         const ttyFd = openSync('/dev/tty', 'r')
         renderContext = { ...renderContext, stdin: new ReadStream(ttyFd) }
       } catch (err) {
-        logError(`Could not open /dev/tty: ${err}`)
+        console.error(`Could not open /dev/tty: ${err}`)
       }
     }
   }
@@ -392,19 +392,21 @@ ${commandList}`,
         ])
         // logStartup()
         const inputPrompt = [prompt, stdinContent].filter(Boolean).join('\n')
-        
+
         // 检查是否为TTY环境
         const isTTY = process.stdin.isTTY && process.stdout.isTTY
-        
+
         // 非TTY环境自动降级为 --print 模式
         if (!isTTY && !print) {
           if (!inputPrompt) {
-            console.error("No TTY detected. Use `-p/--print` with a prompt or pipe input.")
+            console.error(
+              'No TTY detected. Use `-p/--print` with a prompt or pipe input.',
+            )
             process.exit(1)
           }
           print = true
         }
-        
+
         if (print) {
           if (!inputPrompt) {
             console.error(


### PR DESCRIPTION
## Summary
- Surface `/dev/tty` access errors directly to stderr
- Ensure CLI auto-switches to `--print` mode or exits when run without a TTY

## Testing
- `npm run build`
- `npx prettier src/entrypoints/cli.tsx --check`


------
https://chatgpt.com/codex/tasks/task_e_6899ba6c29008327a99745ab0ead7314