### PR TITLE
refactor: break CustomSelect circular deps

### DIFF
--- a/src/components/CustomSelect/option-map.ts
+++ b/src/components/CustomSelect/option-map.ts
@@ -1,5 +1,5 @@
 import { type Option } from '@inkjs/ui'
-import { optionHeaderKey, type OptionHeader } from './select'
+import { optionHeaderKey, type OptionHeader } from './types'
 
 type OptionMapItem = (Option | OptionHeader) & {
   previous: OptionMapItem | undefined

--- a/src/components/CustomSelect/select.tsx
+++ b/src/components/CustomSelect/select.tsx
@@ -5,27 +5,10 @@ import { type Theme } from './theme'
 import { useSelectState } from './use-select-state'
 import { useSelect } from './use-select'
 import { Option, useComponentTheme } from '@inkjs/ui'
+import { type OptionSubtree, type OptionHeader, optionHeaderKey } from './types'
 
-export type OptionSubtree = {
-  /**
-   * Header to show above sub-options.
-   */
-  readonly header?: string
-
-  /**
-   * Options.
-   */
-  readonly options: (Option | OptionSubtree)[]
-}
-
-export type OptionHeader = {
-  readonly header: string
-
-  readonly optionValues: string[]
-}
-
-export const optionHeaderKey = (optionHeader: OptionHeader): string =>
-  `HEADER-${optionHeader.optionValues.join(',')}`
+export type { OptionSubtree, OptionHeader } from './types'
+export { optionHeaderKey } from './types'
 
 export type SelectProps = {
   /**

--- a/src/components/CustomSelect/types.ts
+++ b/src/components/CustomSelect/types.ts
@@ -1,0 +1,22 @@
+import { type Option } from '@inkjs/ui'
+
+export type OptionSubtree = {
+  /**
+   * Header to show above sub-options.
+   */
+  readonly header?: string
+
+  /**
+   * Options.
+   */
+  readonly options: (Option | OptionSubtree)[]
+}
+
+export type OptionHeader = {
+  readonly header: string
+
+  readonly optionValues: string[]
+}
+
+export const optionHeaderKey = (optionHeader: OptionHeader): string =>
+  `HEADER-${optionHeader.optionValues.join(',')}`

--- a/src/components/CustomSelect/use-select-state.ts
+++ b/src/components/CustomSelect/use-select-state.ts
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import OptionMap from './option-map'
 import { Option } from '@inkjs/ui'
-import type { OptionHeader, OptionSubtree } from './select'
+import type { OptionHeader, OptionSubtree } from './types'
 
 type State = {
   /**

--- a/src/components/permissions/toolUseOptions.ts
+++ b/src/components/permissions/toolUseOptions.ts
@@ -7,7 +7,7 @@ import {
 import { isUnsafeCompoundCommand } from '../../utils/commands'
 import { getCwd } from '../../utils/state'
 import { getTheme } from '../../utils/theme'
-import { type OptionSubtree } from '../CustomSelect/select'
+import { type OptionSubtree } from '../CustomSelect/types'
 
 /**
  * Generates options for the tool use confirmation dialog


### PR DESCRIPTION
## Summary
- move CustomSelect option types and helper to dedicated module to avoid cyclic imports
- update Select, OptionMap, useSelectState, and permission helpers to consume the shared types

## Testing
- `npm run format:check` (fails: Code style issues found in 4 files)
- `node test-simple.js` (fails: Cannot find module '/workspace/anon-k')
- `node test-non-tty.js` (fails: Cannot find module '/workspace/anon-kode/cli.mjs')
- `node test-cli.js` (fails: Cannot find module '/workspace/anon-k')
- `node test-core-logic.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899ccca5904832783729f381cb85a67