### PR TITLE
refactor: break circular dependencies

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -16,7 +16,7 @@ import { readFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { getSlowAndCapableModel } from './utils/model'
 import { lastX } from './utils/generators'
-import { getGitEmail } from './utils/user'
+import { getGitEmail } from './utils/git'
 import { PROJECT_FILE } from './constants/product'
 /**
  * Find all KODING.md files in the current working directory

--- a/src/utils/betas.ts
+++ b/src/utils/betas.ts
@@ -1,5 +1,4 @@
 import { memoize } from 'lodash-es'
-import { checkGate } from '../services/statsig'
 import {
   GATE_TOKEN_EFFICIENT_TOOLS,
   BETA_HEADER_TOKEN_EFFICIENT_TOOLS,
@@ -10,6 +9,7 @@ export const getBetas = memoize(async (): Promise<string[]> => {
   const betaHeaders = [CLAUDE_CODE_20250219_BETA_HEADER]
 
   if (process.env.USER_TYPE === 'ant' || process.env.SWE_BENCH) {
+    const { checkGate } = await import('../services/statsig')
     const useTokenEfficientTools = await checkGate(GATE_TOKEN_EFFICIENT_TOOLS)
     if (useTokenEfficientTools) {
       betaHeaders.push(BETA_HEADER_TOKEN_EFFICIENT_TOOLS)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,11 +6,29 @@ import { GLOBAL_CLAUDE_FILE } from './env'
 import { getCwd } from './state'
 import { randomBytes } from 'crypto'
 import { safeParseJSON } from './json'
-import { checkGate, logEvent } from '../services/statsig'
 import { GATE_USE_EXTERNAL_UPDATER } from '../constants/betas'
 import { ConfigParseError } from './errors'
-import type { ThemeNames } from './theme'
 import { getSessionState, setSessionState } from './sessionState'
+
+export type ThemeNames =
+  | 'dark'
+  | 'light'
+  | 'light-daltonized'
+  | 'dark-daltonized'
+
+function logEvent(
+  eventName: string,
+  metadata: { [key: string]: string | undefined },
+): void {
+  import('../services/statsig').then(({ logEvent: statsigLogEvent }) =>
+    statsigLogEvent(eventName, metadata),
+  )
+}
+
+async function checkGate(gateName: string): Promise<boolean> {
+  const { checkGate: statsigCheckGate } = await import('../services/statsig')
+  return statsigCheckGate(gateName)
+}
 
 export type McpStdioServerConfig = {
   type?: 'stdio' // Optional for backwards compatibility

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,8 @@
-import { execFileNoThrow } from './execFileNoThrow'
 import { memoize } from 'lodash-es'
 import { join } from 'path'
 import { homedir } from 'os'
+import { access } from 'fs/promises'
+import { constants } from 'fs'
 import { CONFIG_BASE_DIR, CONFIG_FILE } from '../constants/product'
 // Base directory for all Claude Code data files (except config.json for backwards compatibility)
 export const CLAUDE_BASE_DIR =
@@ -14,12 +15,12 @@ export const GLOBAL_CLAUDE_FILE = process.env.CLAUDE_CONFIG_DIR
 export const MEMORY_DIR = join(CLAUDE_BASE_DIR, 'memory')
 
 const getIsDocker = memoize(async (): Promise<boolean> => {
-  // Check for .dockerenv file
-  const { code } = await execFileNoThrow('test', ['-f', '/.dockerenv'])
-  if (code !== 0) {
+  try {
+    await access('/.dockerenv', constants.F_OK)
+    return process.platform === 'linux'
+  } catch {
     return false
   }
-  return process.platform === 'linux'
 })
 
 const hasInternetAccess = memoize(async (): Promise<boolean> => {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,6 @@
 import { memoize } from 'lodash-es'
 import { execFileNoThrow } from './execFileNoThrow'
+import { logError } from './log'
 
 export const getIsGit = memoize(async (): Promise<boolean> => {
   const { code } = await execFileNoThrow('git', [
@@ -7,6 +8,15 @@ export const getIsGit = memoize(async (): Promise<boolean> => {
     '--is-inside-work-tree',
   ])
   return code === 0
+})
+
+export const getGitEmail = memoize(async (): Promise<string | undefined> => {
+  const result = await execFileNoThrow('git', ['config', 'user.email'])
+  if (result.code !== 0) {
+    logError(`Failed to get git email: ${result.stdout} ${result.stderr}`)
+    return undefined
+  }
+  return result.stdout.trim() || undefined
 })
 
 export const getHead = async (): Promise<string> => {

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,20 +1,11 @@
-import { getGlobalConfig, getOrCreateUserID } from './config'
 import { memoize } from 'lodash-es'
 import { env } from './env'
 import { type StatsigUser } from '@statsig/js-client'
-import { execFileNoThrow } from './execFileNoThrow'
-import { logError, SESSION_ID } from './log'
+import { SESSION_ID } from './log'
 import { MACRO } from '../constants/macros'
-export const getGitEmail = memoize(async (): Promise<string | undefined> => {
-  const result = await execFileNoThrow('git', ['config', 'user.email'])
-  if (result.code !== 0) {
-    logError(`Failed to get git email: ${result.stdout} ${result.stderr}`)
-    return undefined
-  }
-  return result.stdout.trim() || undefined
-})
 
 export const getUser = memoize(async (): Promise<StatsigUser> => {
+  const { getGlobalConfig, getOrCreateUserID } = await import('./config')
   const userID = getOrCreateUserID()
   const config = getGlobalConfig()
   const email = undefined


### PR DESCRIPTION
## Summary
- refactor env to avoid shell-based Docker check
- lazily import Statsig in config, betas, and user helpers
- streamline Statsig service to drop git/model lookups and centralize git email utility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `npm run format:check` (fails: Code style issues found)


------
https://chatgpt.com/codex/tasks/task_e_6899cedf6b5c8327bae0efd030a47068