### PR TITLE
feat: add bun compile script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "dev": "tsx ./src/entrypoints/cli.tsx --verbose",
     "build": "bun build ./src/entrypoints/cli.tsx --outfile=\"$(pwd)/cli.mjs\" --target=node --format=esm --sourcemap ",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "compile": "bun build ./src/entrypoints/cli.tsx --compile --outfile dist-bin/kode --target=node --format=esm && cp yoga.wasm dist-bin/"
   },
   "optionalDependencies": {
     "@img/sharp-darwin-arm64": "^0.33.5",


### PR DESCRIPTION
## Summary
- add `compile` script to package.json to generate a Bun binary and copy yoga.wasm into output directory

## Testing
- `bun run format:check`
- `bun run compile`
- `./dist-bin/kode --help` *(fails: Unexpected identifier 'init_build2')*

------
https://chatgpt.com/codex/tasks/task_e_6899e0fb6e448327b61e5aa125481cb0